### PR TITLE
Add Fish Shell Support 🐟

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# Smart Suggestion for Zsh
+# Smart Suggestion for Zsh & Fish
 
 > [!NOTE]
 >
-> This project is a fork of [zsh-copilot](https://github.com/Myzel394/zsh-copilot) by [Myzel394](https://github.com/Myzel394).
+> This project is a fork of [zsh-copilot](https://github.com/Myzel394/zsh-copilot) by [Myzel394](https://github.com/Myzel394), with added support for fish shell.
 
-Get AI-powered command suggestions **directly** in your zsh shell. No complex setup, no external tools - just press `CTRL + O` and get intelligent command suggestions powered by OpenAI, Anthropic Claude, or Google Gemini.
+Get AI-powered command suggestions **directly** in your zsh or fish shell. No complex setup, no external tools - just press `CTRL + O` and get intelligent command suggestions powered by OpenAI, Anthropic Claude, or Google Gemini.
 
 > [!NOTE]
 >
@@ -29,8 +29,9 @@ Get AI-powered command suggestions **directly** in your zsh shell. No complex se
 
 Make sure you have the following installed:
 
-- **zsh** shell
-- **[zsh-autosuggestions](https://github.com/zsh-users/zsh-autosuggestions)** plugin
+- **zsh** or **fish** shell
+- For zsh: **[zsh-autosuggestions](https://github.com/zsh-users/zsh-autosuggestions)** plugin
+- For fish: Built-in autosuggestions (included by default)
 - An API key for one of the supported AI providers
 
 ### Method 1: Quick Install (Recommended)
@@ -55,7 +56,33 @@ This script will:
 curl -fsSL https://raw.githubusercontent.com/yetone/smart-suggestion/main/install.sh | bash -s -- --uninstall
 ```
 
-### Method 2: Oh My Zsh
+### Method 2: Fisher (for fish) - Recommended for Fish Users
+
+Install with a single command:
+
+```bash
+fisher install yetone/smart-suggestion
+```
+
+That's it! Fisher will automatically:
+- Download the plugin
+- Build the Go binary (requires Go 1.21+)
+- Set up the configuration
+- Make the plugin available immediately
+
+Then set up your AI provider API key:
+
+```bash
+set -Ux OPENAI_API_KEY "your-api-key"     # For OpenAI
+# OR
+set -Ux ANTHROPIC_API_KEY "your-api-key"  # For Anthropic
+# OR
+set -Ux GEMINI_API_KEY "your-api-key"     # For Google Gemini
+```
+
+Start using Smart Suggestion by pressing `Ctrl+O` in your terminal!
+
+### Method 3: Oh My Zsh (for zsh)
 
 1. Clone the repository into your Oh My Zsh custom plugins directory:
 
@@ -83,10 +110,12 @@ cd ${ZSH_CUSTOM:-~/.oh-my-zsh/custom}/plugins/smart-suggestion
 4. Reload your shell:
 
 ```bash
-source ~/.zshrc
+source ~/.zshrc  # for zsh
+# OR
+source ~/.config/fish/config.fish  # for fish
 ```
 
-### Method 3: Manual Installation from Source
+### Method 4: Manual Installation from Source
 
 1. Clone the repository:
 
@@ -104,16 +133,20 @@ cd ~/.config/smart-suggestion
 3. Add to your `~/.zshrc`:
 
 ```bash
-source ~/.config/smart-suggestion/smart-suggestion.plugin.zsh
+source ~/.config/smart-suggestion/smart-suggestion.plugin.zsh  # for zsh
+# OR
+source ~/.config/smart-suggestion/smart-suggestion.plugin.fish  # for fish
 ```
 
 4. Reload your shell:
 
 ```bash
-source ~/.zshrc
+source ~/.zshrc  # for zsh
+# OR
+source ~/.config/fish/config.fish  # for fish
 ```
 
-### Method 4: Manual Installation from Release
+### Method 5: Manual Installation from Release
 
 1. Download the latest release for your platform from [GitHub Releases](https://github.com/yetone/smart-suggestion/releases)
 
@@ -127,13 +160,17 @@ tar -xzf smart-suggestion-*.tar.gz -C ~/.config/smart-suggestion --strip-compone
 3. Add to your `~/.zshrc`:
 
 ```bash
-source ~/.config/smart-suggestion/smart-suggestion.plugin.zsh
+source ~/.config/smart-suggestion/smart-suggestion.plugin.zsh  # for zsh
+# OR
+source ~/.config/smart-suggestion/smart-suggestion.plugin.fish  # for fish
 ```
 
 4. Reload your shell:
 
 ```bash
-source ~/.zshrc
+source ~/.zshrc  # for zsh
+# OR
+source ~/.config/fish/config.fish  # for fish
 ```
 
 ## Configuration
@@ -176,7 +213,7 @@ Configure the plugin behavior with these environment variables:
 | Variable | Description | Default | Options |
 |----------|-------------|---------|---------|
 | `SMART_SUGGESTION_AI_PROVIDER` | AI provider to use | Auto-detected | `openai`, `azure_openai`, `anthropic`, `gemini` |
-| `SMART_SUGGESTION_KEY` | Keybinding to trigger suggestions | `^o` | Any zsh keybinding |
+| `SMART_SUGGESTION_KEY` | Keybinding to trigger suggestions | `^o` (zsh), `\co` (fish) | Any shell keybinding |
 | `SMART_SUGGESTION_SEND_CONTEXT` | Send shell context to AI | `true` | `true`, `false` |
 | `SMART_SUGGESTION_PROXY_MODE` | Enable proxy mode for better context | `true` | `true`, `false` |
 | `SMART_SUGGESTION_DEBUG` | Enable debug logging | `false` | `true`, `false` |
@@ -229,7 +266,7 @@ smart-suggestion
 3. **Context Collection**: Gathers rich shell context including user info, directory, command history, aliases, and terminal buffer content via proxy mode
 4. **AI Processing**: Sends the input and context to your configured AI provider
 5. **Smart Response**: AI returns either a completion (`+`) or new command (`=`)
-6. **Shell Integration**: The suggestion is displayed using zsh-autosuggestions or replaces your input
+6. **Shell Integration**: The suggestion is displayed using shell-specific autosuggestions (zsh-autosuggestions for zsh, built-in for fish) or replaces your input
 
 ### Proxy Mode (New Default)
 

--- a/conf.d/smart_suggestion.fish
+++ b/conf.d/smart_suggestion.fish
@@ -1,0 +1,8 @@
+# Smart Suggestion initialization for Fisher
+# This file is automatically sourced by fish when the plugin is installed via Fisher
+
+# Set the plugin directory
+set -l plugin_dir (dirname (status --current-filename))/..
+
+# Source the fish plugin
+source $plugin_dir/smart-suggestion.plugin.fish

--- a/conf.d/smart_suggestion_install.fish
+++ b/conf.d/smart_suggestion_install.fish
@@ -1,0 +1,68 @@
+# Fisher install hook for Smart Suggestion
+# This script runs when the plugin is installed via Fisher
+
+function _smart_suggestion_install --on-event smart_suggestion_install
+    echo "🚀 Installing Smart Suggestion..."
+    
+    # Get the plugin installation directory
+    set -l plugin_dir $__fish_config_dir/fisher/github.com/(basename (status --current-filename | string replace '_install.fish' ''))
+    
+    # Find the actual plugin directory (Fisher might install to different paths)
+    for dir in $__fish_config_dir/fisher/*smart-suggestion* ~/.local/share/fisher/*smart-suggestion*
+        if test -d $dir -a -f $dir/build.sh
+            set plugin_dir $dir
+            break
+        end
+    end
+    
+    if not test -d $plugin_dir
+        echo "❌ Could not find Smart Suggestion plugin directory"
+        return 1
+    end
+    
+    echo "📁 Plugin directory: $plugin_dir"
+    
+    # Check if Go is available
+    if not command -q go
+        echo "❌ Go is required to build Smart Suggestion binary"
+        echo "   Please install Go from https://golang.org/dl/"
+        return 1
+    end
+    
+    # Build the binary
+    echo "🔨 Building Smart Suggestion binary..."
+    if pushd $plugin_dir >/dev/null 2>&1
+        if ./build.sh
+            echo "✅ Smart Suggestion binary built successfully!"
+            
+            # Create the target directory if it doesn't exist
+            mkdir -p ~/.config/smart-suggestion
+            
+            # Copy files to the standard location
+            cp smart-suggestion ~/.config/smart-suggestion/
+            cp smart-suggestion-core.sh ~/.config/smart-suggestion/
+            cp smart-suggestion.plugin.fish ~/.config/smart-suggestion/
+            
+            echo "✅ Smart Suggestion installed successfully!"
+            echo ""
+            echo "📋 Next steps:"
+            echo "1. Set up your AI provider API key:"
+            echo "   set -Ux OPENAI_API_KEY 'your-api-key'     # For OpenAI"
+            echo "   set -Ux ANTHROPIC_API_KEY 'your-api-key'  # For Anthropic"
+            echo "   set -Ux GEMINI_API_KEY 'your-api-key'     # For Google Gemini"
+            echo ""
+            echo "2. Use Smart Suggestion:"
+            echo "   - Type a command or describe what you want to do"
+            echo "   - Press Ctrl+O to get AI suggestions"
+            echo ""
+            echo "3. Run 'smart-suggestion' to see configuration options"
+        else
+            echo "❌ Failed to build Smart Suggestion binary"
+            return 1
+        end
+        popd >/dev/null 2>&1
+    else
+        echo "❌ Could not change to plugin directory: $plugin_dir"
+        return 1
+    end
+end

--- a/conf.d/smart_suggestion_uninstall.fish
+++ b/conf.d/smart_suggestion_uninstall.fish
@@ -1,0 +1,18 @@
+# Fisher uninstall hook for Smart Suggestion
+# This script runs when the plugin is uninstalled via Fisher
+
+function _smart_suggestion_uninstall --on-event smart_suggestion_uninstall
+    echo "🗑️  Uninstalling Smart Suggestion..."
+    
+    # Remove the installation directory
+    if test -d ~/.config/smart-suggestion
+        rm -rf ~/.config/smart-suggestion
+        echo "✅ Removed Smart Suggestion installation directory"
+    end
+    
+    # Clean up any temporary files
+    rm -f /tmp/smart_suggestion /tmp/.smart_suggestion_error
+    
+    echo "✅ Smart Suggestion uninstalled successfully!"
+    echo "   You may need to restart your shell to complete the removal."
+end

--- a/fisher.yml
+++ b/fisher.yml
@@ -1,0 +1,16 @@
+name: smart-suggestion
+description: AI-powered command suggestions for fish shell
+version: 1.0.0
+author: yetone
+homepage: https://github.com/yetone/smart-suggestion
+keywords:
+  - ai
+  - suggestions
+  - productivity
+  - fish
+  - shell
+dependencies: []
+requirements:
+  - go: ">=1.21"
+install_script: conf.d/smart_suggestion_install.fish
+uninstall_script: conf.d/smart_suggestion_uninstall.fish

--- a/functions/smart-suggestion.fish
+++ b/functions/smart-suggestion.fish
@@ -1,0 +1,10 @@
+# Smart Suggestion function for Fisher
+# This makes the smart-suggestion command available globally
+
+function smart-suggestion --description 'Show Smart Suggestion configuration'
+    # Get the plugin directory
+    set -l plugin_dir (dirname (status --current-filename))/..
+    
+    # Source the core and show config
+    bash -c 'source "'$plugin_dir'/smart-suggestion-core.sh" && smart_suggestion_show_config'
+end

--- a/install.sh
+++ b/install.sh
@@ -334,8 +334,9 @@ case "${1:-}" in
         echo "Usage: $0 [options]"
         echo ""
         echo "Options:"
-        echo "  --help, -h     Show this help message"
-        echo "  --uninstall    Uninstall smart-suggestion"
+        echo "  --help, -h            Show this help message"
+        echo "  --shell [zsh|fish]    Install for specific shell (auto-detected if not specified)"
+        echo "  --uninstall           Uninstall smart-suggestion"
         echo ""
         echo "Environment variables:"
         echo "  INSTALL_DIR    Installation directory (default: $INSTALL_DIR)"
@@ -364,13 +365,20 @@ case "${1:-}" in
         echo "Please restart your shell or run: source ~/.zshrc"
         exit 0
         ;;
+    --shell)
+        # Shell specified
+        detect_shell "$@"
+        main
+        ;;
     "")
         # Default installation
+        detect_shell
         main
         ;;
     *)
         log_error "Unknown option: $1"
         echo "Use --help for usage information"
+        echo "Supported options: --shell [zsh|fish], --uninstall"
         exit 1
         ;;
 esac

--- a/smart-suggestion-core.sh
+++ b/smart-suggestion-core.sh
@@ -1,0 +1,181 @@
+#!/bin/bash
+
+# Smart Suggestion Core Functions
+# Shared functionality between zsh and fish plugins
+
+# Set default configurations if not already set
+smart_suggestion_set_defaults() {
+    # Default key binding - shell-specific plugins will handle this
+    : ${SMART_SUGGESTION_KEY:='^o'}
+    
+    # Configuration options
+    : ${SMART_SUGGESTION_SEND_CONTEXT:=true}
+    : ${SMART_SUGGESTION_DEBUG:=false}
+    : ${SMART_SUGGESTION_PROXY_MODE:=true}
+    
+    # Auto-detect AI provider if not set
+    if [[ -z "$SMART_SUGGESTION_AI_PROVIDER" ]]; then
+        if [[ -n "$OPENAI_API_KEY" ]]; then
+            export SMART_SUGGESTION_AI_PROVIDER="openai"
+        elif [[ -n "$AZURE_OPENAI_API_KEY" && -n "$AZURE_OPENAI_RESOURCE_NAME" && -n "$AZURE_OPENAI_DEPLOYMENT_NAME" ]]; then
+            typeset -g SMART_SUGGESTION_AI_PROVIDER="azure_openai"
+        elif [[ -n "$ANTHROPIC_API_KEY" ]]; then
+            export SMART_SUGGESTION_AI_PROVIDER="anthropic"
+        elif [[ -n "$GEMINI_API_KEY" ]]; then
+            export SMART_SUGGESTION_AI_PROVIDER="gemini"
+        else
+            echo "No AI provider selected. Please set either OPENAI_API_KEY or AZURE_OPENAI_API_KEY (with AZURE_OPENAI_RESOURCE_NAME and AZURE_OPENAI_DEPLOYMENT_NAME) or ANTHROPIC_API_KEY or GEMINI_API_KEY."
+            return 1
+        fi
+    fi
+    
+    # Create debug log if needed
+    if [[ "$SMART_SUGGESTION_DEBUG" == 'true' ]]; then
+        touch /tmp/smart-suggestion.log
+    fi
+    
+    return 0
+}
+
+# Get the binary path
+smart_suggestion_get_binary_path() {
+    # Try multiple locations for the binary
+    local locations=(
+        "$HOME/.config/smart-suggestion/smart-suggestion"
+        "$(dirname "${BASH_SOURCE[0]}")/smart-suggestion"
+        "./smart-suggestion"
+    )
+    
+    for location in "${locations[@]}"; do
+        if [[ -f "$location" ]]; then
+            echo "$location"
+            return 0
+        fi
+    done
+    
+    # Default to the config location
+    echo "$HOME/.config/smart-suggestion/smart-suggestion"
+}
+
+# Check if binary exists
+smart_suggestion_check_binary() {
+    local binary_path=$(smart_suggestion_get_binary_path)
+    if [[ ! -f "$binary_path" ]]; then
+        echo "smart-suggestion binary not found at $binary_path. Please run ./build.sh to build it."
+        return 1
+    fi
+    return 0
+}
+
+# Run the proxy mode
+smart_suggestion_run_proxy() {
+    local binary_path=$(smart_suggestion_get_binary_path)
+    if ! smart_suggestion_check_binary; then
+        return 1
+    fi
+    "$binary_path" proxy
+}
+
+# Fetch suggestions from AI
+smart_suggestion_fetch() {
+    local input="$1"
+    local binary_path=$(smart_suggestion_get_binary_path)
+    
+    # Check if the binary exists
+    if ! smart_suggestion_check_binary; then
+        echo "smart-suggestion binary not found at $binary_path. Please run ./build.sh to build it." > /tmp/.smart_suggestion_error
+        return 1
+    fi
+    
+    # Prepare debug flag
+    local debug_flag=""
+    if [[ "$SMART_SUGGESTION_DEBUG" == 'true' ]]; then
+        debug_flag="--debug"
+    fi
+    
+    # Prepare context flag
+    local context_flag=""
+    if [[ "$SMART_SUGGESTION_SEND_CONTEXT" == 'true' ]]; then
+        context_flag="--context"
+    fi
+    
+    # Call the Go binary with proper arguments
+    "$binary_path" \
+        --provider "$SMART_SUGGESTION_AI_PROVIDER" \
+        --input "$input" \
+        --output "/tmp/smart_suggestion" \
+        $debug_flag \
+        $context_flag
+    
+    return $?
+}
+
+# Show loading animation
+smart_suggestion_show_loading() {
+    local pid=$1
+    local interval=0.1
+    local animation_chars=("⠋" "⠙" "⠹" "⠸" "⠼" "⠴" "⠦" "⠧" "⠇" "⠏")
+    local i=0
+
+    cleanup() {
+        kill $pid 2>/dev/null
+        printf "\e[?25h"
+    }
+    trap cleanup SIGINT
+    
+    while kill -0 $pid 2>/dev/null; do
+        # Display current animation frame
+        printf "%s\r" "${animation_chars[i]}"
+
+        # Update index
+        i=$(( (i + 1) % ${#animation_chars[@]} ))
+        
+        sleep $interval
+    done
+
+    printf "\e[?25h"
+    trap - SIGINT
+}
+
+# Process the suggestion response
+smart_suggestion_process_response() {
+    if [[ ! -f /tmp/smart_suggestion ]]; then
+        cat /tmp/.smart_suggestion_error 2>/dev/null || echo "No suggestion available at this time. Please try again later."
+        return 1
+    fi
+
+    local message=$(cat /tmp/smart_suggestion)
+    local first_char=${message:0:1}
+    local suggestion=${message:1:${#message}}
+    
+    # Return the type and suggestion for shell-specific handling
+    echo "$first_char|$suggestion"
+    return 0
+}
+
+# Log debug information
+smart_suggestion_log_debug() {
+    local input="$1"
+    local response_code="$2"
+    
+    if [[ "$SMART_SUGGESTION_DEBUG" == 'true' ]]; then
+        echo "{\"date\":\"$(date)\",\"log\":\"Fetched message\",\"input\":\"$input\",\"response_code\":\"$response_code\"}" >> /tmp/smart-suggestion.log
+    fi
+}
+
+# Show configuration information
+smart_suggestion_show_config() {
+    echo "Smart Suggestion is now active. Press $SMART_SUGGESTION_KEY to get suggestions."
+    echo ""
+    echo "Configurations:"
+    echo "    - SMART_SUGGESTION_KEY: Key to press to get suggestions (default: ^o, value: $SMART_SUGGESTION_KEY)."
+    echo "    - SMART_SUGGESTION_SEND_CONTEXT: If \`true\`, smart-suggestion will send context information (whoami, shell, pwd, etc.) to the AI model (default: true, value: $SMART_SUGGESTION_SEND_CONTEXT)."
+    echo "    - SMART_SUGGESTION_AI_PROVIDER: AI provider to use ('openai', 'azure_openai', 'anthropic', or 'gemini', value: $SMART_SUGGESTION_AI_PROVIDER)."
+    echo "    - SMART_SUGGESTION_DEBUG: Enable debug logging (default: false, value: $SMART_SUGGESTION_DEBUG)."
+}
+
+# Clean up temporary files
+smart_suggestion_cleanup() {
+    rm -f /tmp/smart_suggestion
+    rm -f /tmp/.smart_suggestion_error
+}

--- a/smart-suggestion.plugin.fish
+++ b/smart-suggestion.plugin.fish
@@ -1,0 +1,132 @@
+#!/usr/bin/env fish
+
+# Smart Suggestion Plugin for Fish
+# Determine the plugin directory and core script location
+set -l plugin_dir (dirname (status --current-filename))
+
+# Try to find the core script in multiple locations (for different installation methods)
+set -g core_script ""
+for location in "$plugin_dir/smart-suggestion-core.sh" "$HOME/.config/smart-suggestion/smart-suggestion-core.sh"
+    if test -f $location
+        set -g core_script $location
+        break
+    end
+end
+
+if test -z "$core_script"
+    echo "❌ Smart Suggestion core script not found. Please ensure the plugin is properly installed."
+    return 1
+end
+
+# Set up default configurations  
+if not bash -c "source '$core_script' && smart_suggestion_set_defaults"
+    return 1
+end
+
+# Set fish-specific defaults
+set -q SMART_SUGGESTION_KEY; or set -g SMART_SUGGESTION_KEY \ca
+set -q SMART_SUGGESTION_SEND_CONTEXT; or set -g SMART_SUGGESTION_SEND_CONTEXT true
+set -q SMART_SUGGESTION_DEBUG; or set -g SMART_SUGGESTION_DEBUG false
+set -q SMART_SUGGESTION_PROXY_MODE; or set -g SMART_SUGGESTION_PROXY_MODE true
+
+# Auto-detect AI provider if not set
+if not set -q SMART_SUGGESTION_AI_PROVIDER
+    if set -q OPENAI_API_KEY; and test -n "$OPENAI_API_KEY"
+        set -g SMART_SUGGESTION_AI_PROVIDER openai
+    else if set -q ANTHROPIC_API_KEY; and test -n "$ANTHROPIC_API_KEY"
+        set -g SMART_SUGGESTION_AI_PROVIDER anthropic
+    else if set -q GEMINI_API_KEY; and test -n "$GEMINI_API_KEY"
+        set -g SMART_SUGGESTION_AI_PROVIDER gemini
+    end
+end
+
+function _run_smart_suggestion_proxy
+    if status is-interactive
+        bash -c "source \"$core_script\" && smart_suggestion_run_proxy"
+    end
+end
+
+function _fetch_suggestions
+    set -l input $argv[1]
+    bash -c "source \"$core_script\" && smart_suggestion_fetch \"$input\""
+    return $status
+end
+
+function _show_loading_animation
+    set -l pid $argv[1]
+    bash -c "source \"$core_script\" && smart_suggestion_show_loading $pid"
+end
+
+function _do_smart_suggestion
+    # Get current command line input
+    set -l input (commandline -b)
+    
+    if test -z "$input"
+        set input "help me with a command"
+    end
+    
+    # Clean up temporary files
+    bash -c "source \"$core_script\" && smart_suggestion_cleanup" 2>/dev/null
+    
+    # Call the Go binary directly  
+    env SMART_SUGGESTION_KEY="$SMART_SUGGESTION_KEY" \
+        SMART_SUGGESTION_SEND_CONTEXT="$SMART_SUGGESTION_SEND_CONTEXT" \
+        SMART_SUGGESTION_DEBUG="$SMART_SUGGESTION_DEBUG" \
+        SMART_SUGGESTION_PROXY_MODE="$SMART_SUGGESTION_PROXY_MODE" \
+        SMART_SUGGESTION_AI_PROVIDER="$SMART_SUGGESTION_AI_PROVIDER" \
+        bash -c "source \"$core_script\" && smart_suggestion_fetch \"$input\"" 2>/dev/null
+    
+    # Process the response
+    set -l response (bash -c "source \"$core_script\" && smart_suggestion_process_response" 2>/dev/null)
+    if test $status -ne 0
+        return 1
+    end
+
+    # Parse response (split on |)
+    set -l response_parts (string split '|' $response)
+    if test (count $response_parts) -ge 2
+        set -l first_char $response_parts[1]
+        set -l suggestion $response_parts[2]
+
+        # Handle the suggestion based on type
+        if test "$first_char" = '='
+            # Replace current command line
+            commandline -r "$suggestion"
+        else if test "$first_char" = '+'
+            # Append to current command line
+            commandline -i "$suggestion"
+        end
+    end
+    
+    commandline -f repaint
+end
+
+function smart-suggestion
+    # Check if core script exists
+    if test -z "$core_script" -o ! -f "$core_script"
+        echo "❌ Smart Suggestion core script not found"
+        return 1
+    end
+    
+    # Pass fish environment variables to bash
+    env SMART_SUGGESTION_KEY="$SMART_SUGGESTION_KEY" \
+        SMART_SUGGESTION_SEND_CONTEXT="$SMART_SUGGESTION_SEND_CONTEXT" \
+        SMART_SUGGESTION_DEBUG="$SMART_SUGGESTION_DEBUG" \
+        SMART_SUGGESTION_PROXY_MODE="$SMART_SUGGESTION_PROXY_MODE" \
+        SMART_SUGGESTION_AI_PROVIDER="$SMART_SUGGESTION_AI_PROVIDER" \
+        bash -c "source \"$core_script\" && smart_suggestion_show_config"
+end
+
+# Set up key binding for ALL modes - works with and without vim mode
+# This covers both vim mode users and regular users
+bind -M insert \co '_do_smart_suggestion; commandline -f repaint'    # vim insert mode
+bind -M default \co '_do_smart_suggestion; commandline -f repaint'   # normal mode & non-vim users  
+bind -M visual \co '_do_smart_suggestion; commandline -f repaint'    # vim visual mode
+
+# Also bind to the global scope as fallback for any other modes
+bind \co '_do_smart_suggestion; commandline -f repaint'
+
+# Start proxy mode if enabled and not in tmux
+if test "$SMART_SUGGESTION_PROXY_MODE" = "true" -a -z "$TMUX"
+    _run_smart_suggestion_proxy
+end

--- a/smart-suggestion.plugin.zsh
+++ b/smart-suggestion.plugin.zsh
@@ -1,153 +1,65 @@
 #!/usr/bin/env zsh
 
-# Default key binding
+# Smart Suggestion Plugin for Zsh
+# Source the shared core functions
+source "${0:A:h}/smart-suggestion-core.sh"
+
+# Set up default configurations
+smart_suggestion_set_defaults || return 1
+
+# Zsh-specific key binding default
 (( ! ${+SMART_SUGGESTION_KEY} )) &&
     typeset -g SMART_SUGGESTION_KEY='^o'
 
-# Configuration options
-(( ! ${+SMART_SUGGESTION_SEND_CONTEXT} )) &&
-    typeset -g SMART_SUGGESTION_SEND_CONTEXT=true
-
-(( ! ${+SMART_SUGGESTION_DEBUG} )) &&
-    typeset -g SMART_SUGGESTION_DEBUG=false
-
-# Proxy mode configuration - now enabled by default
-(( ! ${+SMART_SUGGESTION_PROXY_MODE} )) &&
-    typeset -g SMART_SUGGESTION_PROXY_MODE=true
-
-# New option to select AI provider
-if [[ -z "$SMART_SUGGESTION_AI_PROVIDER" ]]; then
-    if [[ -n "$OPENAI_API_KEY" ]]; then
-        typeset -g SMART_SUGGESTION_AI_PROVIDER="openai"
-    elif [[ -n "$AZURE_OPENAI_API_KEY" && -n "$AZURE_OPENAI_RESOURCE_NAME" && -n "$AZURE_OPENAI_DEPLOYMENT_NAME" ]]; then
-        typeset -g SMART_SUGGESTION_AI_PROVIDER="azure_openai"
-    elif [[ -n "$ANTHROPIC_API_KEY" ]]; then
-        typeset -g SMART_SUGGESTION_AI_PROVIDER="anthropic"
-    elif [[ -n "$GEMINI_API_KEY" ]]; then
-        typeset -g SMART_SUGGESTION_AI_PROVIDER="gemini"
-    else
-        echo "No AI provider selected. Please set either OPENAI_API_KEY or AZURE_OPENAI_API_KEY (with AZURE_OPENAI_RESOURCE_NAME and AZURE_OPENAI_DEPLOYMENT_NAME) or ANTHROPIC_API_KEY or GEMINI_API_KEY."
-        return 1
-    fi
-fi
-
-if [[ "$SMART_SUGGESTION_DEBUG" == 'true' ]]; then
-    touch /tmp/smart-suggestion.log
-fi
-
 function _run_smart_suggestion_proxy() {
     if [[ $- == *i* ]]; then
-        local binary_path="$HOME/.config/smart-suggestion/smart-suggestion"
-        if [[ ! -f "$binary_path" ]]; then
-            echo "smart-suggestion binary not found at $binary_path. Please run ./build.sh to build it."
-            return 1
-        fi
-        "$binary_path" proxy
+        smart_suggestion_run_proxy
     fi
 }
 
 function _fetch_suggestions() {
-    local binary_path="$HOME/.config/smart-suggestion/smart-suggestion"
-    
-    # Check if the binary exists
-    if [[ ! -f "$binary_path" ]]; then
-        echo "smart-suggestion binary not found at $binary_path. Please run ./build.sh to build it." > /tmp/.smart_suggestion_error
-        return 1
-    fi
-    
-    # Prepare debug flag
-    local debug_flag=""
-    if [[ "$SMART_SUGGESTION_DEBUG" == 'true' ]]; then
-        debug_flag="--debug"
-    fi
-    
-    # Prepare context flag
-    local context_flag=""
-    if [[ "$SMART_SUGGESTION_SEND_CONTEXT" == 'true' ]]; then
-        context_flag="--context"
-    fi
-    
-    # Call the Go binary with proper arguments
-    "$binary_path" \
-        --provider "$SMART_SUGGESTION_AI_PROVIDER" \
-        --input "$input" \
-        --output "/tmp/smart_suggestion" \
-        $debug_flag \
-        $context_flag
-    
+    smart_suggestion_fetch "$input"
     return $?
 }
 
-
 function _show_loading_animation() {
-    local pid=$1
-    local interval=0.1
-    local animation_chars=("⠋" "⠙" "⠹" "⠸" "⠼" "⠴" "⠦" "⠧" "⠇" "⠏")
-    local i=1
-
-    cleanup() {
-      kill $pid
-      echo -ne "\e[?25h"
-    }
-    trap cleanup SIGINT
-    
-    while kill -0 $pid 2>/dev/null; do
-        # Display current animation frame
-        zle -R "${animation_chars[i]}"
-
-        # Update index, make sure it starts at 1
-        i=$(( (i + 1) % ${#animation_chars[@]} ))
-
-        if [[ $i -eq 0 ]]; then
-            i=1
-        fi
-        
-        sleep $interval
-    done
-
-    echo -ne "\e[?25h"
-    trap - SIGINT
+    smart_suggestion_show_loading $1
 }
 
 function _do_smart_suggestion() {
-    ##### Get input
-    rm -f /tmp/smart_suggestion
-    rm -f /tmp/.smart_suggestion_error
+    # Clean up and get input
+    smart_suggestion_cleanup
     local input=$(echo "${BUFFER:0:$CURSOR}" | tr '\n' ';')
 
     _zsh_autosuggest_clear
 
-    ##### Fetch message
+    # Fetch message in background
     read < <(_fetch_suggestions & echo $!)
     local pid=$REPLY
 
     _show_loading_animation $pid
     local response_code=$?
 
-    if [[ "$SMART_SUGGESTION_DEBUG" == 'true' ]]; then
-        echo "{\"date\":\"$(date)\",\"log\":\"Fetched message\",\"input\":\"$input\",\"response_code\":\"$response_code\"}" >> /tmp/smart-suggestion.log
-    fi
+    # Log debug info
+    smart_suggestion_log_debug "$input" "$response_code"
 
-    if [[ ! -f /tmp/smart_suggestion ]]; then
+    # Process the response
+    local response=$(smart_suggestion_process_response)
+    if [[ $? -ne 0 ]]; then
         _zsh_autosuggest_clear
-        echo $(cat /tmp/.smart_suggestion_error 2>/dev/null || echo "No suggestion available at this time. Please try again later.")
+        echo "$response"
         return 1
     fi
 
-    local message=$(cat /tmp/smart_suggestion)
+    # Parse response
+    local first_char=${response%%|*}
+    local suggestion=${response#*|}
 
-    ##### Process response
-
-    local first_char=${message:0:1}
-    local suggestion=${message:1:${#message}}
-
-    ##### And now, let's actually show the suggestion to the user!
-
+    # Handle the suggestion based on type
     if [[ "$first_char" == '=' ]]; then
         # Reset user input
         BUFFER=""
         CURSOR=0
-
         zle -U "$suggestion"
     elif [[ "$first_char" == '+' ]]; then
         _zsh_autosuggest_suggest "$suggestion"
@@ -155,18 +67,14 @@ function _do_smart_suggestion() {
 }
 
 function smart-suggestion() {
-    echo "Smart Suggestion is now active. Press $SMART_SUGGESTION_KEY to get suggestions."
-    echo ""
-    echo "Configurations:"
-    echo "    - SMART_SUGGESTION_KEY: Key to press to get suggestions (default: ^o, value: $SMART_SUGGESTION_KEY)."
-    echo "    - SMART_SUGGESTION_SEND_CONTEXT: If \`true\`, smart-suggestion will send context information (whoami, shell, pwd, etc.) to the AI model (default: true, value: $SMART_SUGGESTION_SEND_CONTEXT)."
-    echo "    - SMART_SUGGESTION_AI_PROVIDER: AI provider to use ('openai', 'azure_openai', 'anthropic', or 'gemini', value: $SMART_SUGGESTION_AI_PROVIDER)."
-    echo "    - SMART_SUGGESTION_DEBUG: Enable debug logging (default: false, value: $SMART_SUGGESTION_DEBUG)."
+    smart_suggestion_show_config
 }
 
+# Set up key binding
 zle -N _do_smart_suggestion
 bindkey "$SMART_SUGGESTION_KEY" _do_smart_suggestion
 
+# Start proxy mode if enabled and not in tmux
 if [[ "$SMART_SUGGESTION_PROXY_MODE" == "true" && -z "$TMUX" ]]; then
     _run_smart_suggestion_proxy
 fi


### PR DESCRIPTION
First off - awesome project (like always!).
I really wanted to use it, but since I'm on [Fish shell](https://fishshell.com/) I tried to add support for it. 
This is my first attempt at building a [Fisher plugin](https://github.com/jorgebucaran/fisher), so let me know if anything looks off.

If you're open to adding Fish support, here's a quick overview of the changes:

## Summary
- Adds Fish shell support alongside existing ZSH support
- Introduces a shared core script to reduce code duplication
- Adds Fisher plugin compatibility
- Updates docs for dual-shell setup
- Preserves full backwards compatibility with ZSH installs

## Features
- smart-suggestion.plugin.fish: Fish plugin wrapper
- smart-suggestion-core.sh: Shared logic used by both shell plugins
- Installer auto-detects shell type
- Universal key bindings (Vim mode supported!)
- Fisher installation instructions included in README

Thanks again for the tool!
Let me know if you’d like any changes or want to keep this ZSH-only.