### PR TITLE
doc: update environment variable names for API endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,9 +194,10 @@ Configure the plugin behavior with these environment variables:
 #### Custom API URLs
 
 ```bash
-export OPENAI_API_URL="your-custom-openai-endpoint.com"
-export ANTHROPIC_API_URL="your-custom-anthropic-endpoint.com"
-export GEMINI_API_URL="your-custom-gemini-endpoint.com"
+export OPENAI_BASE_URL="your-custom-openai-endpoint.com"
+export AZURE_OPENAI_BASE_URL="your-custom-azure-openai-endpoint.com"
+export ANTHROPIC_BASE_URL="your-custom-anthropic-endpoint.com"
+export GEMINI_BASE_URL="your-custom-gemini-endpoint.com"
 export DEEPSEEK_BASE_URL="your-custom-deepseek-endpoint.com"
 ```
 


### PR DESCRIPTION
fix #13 

- Changed OPENAI_API_URL to OPENAI_BASE_URL
- Added AZURE_OPENAI_BASE_URL for Azure OpenAI endpoint
- Updated ANTHROPIC_API_URL to ANTHROPIC_BASE_URL
- Updated GEMINI_API_URL to GEMINI_BASE_URL

These changes fix clarity and consistency in naming conventions for API configuration.